### PR TITLE
Custom Blog index page

### DIFF
--- a/blog/2023-06-26-welcome/index.md
+++ b/blog/2023-06-26-welcome/index.md
@@ -3,8 +3,10 @@ slug: hello-prem
 title: Hello Prem!
 authors: [filippopedrazzinfp]
 tags: [llm, self-hosted, prem, open-source, welcome]
+description: "Hello, I am Filippo and I am currently contributing to Prem."
+image: "./banner.png"
 ---
-
+<!-- truncate -->
 ![Prem Banner](./banner.png)
 
 Hello, I am Filippo and I am currently contributing to Prem.

--- a/blog/2023-07-01-perplexity-ai-self-hosted/index.md
+++ b/blog/2023-07-01-perplexity-ai-self-hosted/index.md
@@ -3,7 +3,10 @@ slug: perplexity-ai-self-hosted
 title: Build a Perplexity AI clone on Prem
 authors: [tiero]
 tags: [llm, ai, self-hosted, prem, open-source, perplexity, paperspace, dolly]
+description: "Build your own Perplexity AI clone with Prem using the `Dolly v2 12B` model, self-hosted on Paperspace Cloud virtual server."
+image: "./screenshot.png"
 ---
+<!--truncate-->
 
 <head>
   <meta name="twitter:image" content="./screenshot.png"/>
@@ -12,7 +15,6 @@ tags: [llm, ai, self-hosted, prem, open-source, perplexity, paperspace, dolly]
 Build your own Perplexity AI clone with [Prem](https://premai.io) using the `Dolly v2 12B` model, self-hosted on [Paperspace Cloud](https://www.paperspace.com/gpu-cloud) virtual server.
 
 ![Clarity AI Screenshot](./screenshot.png)
-<!--truncate-->
 
 ### What is Perplexity AI?
 

--- a/blog/2023-07-03-serve-falcon-with-fastapi-and-docker/index.md
+++ b/blog/2023-07-03-serve-falcon-with-fastapi-and-docker/index.md
@@ -3,8 +3,10 @@ slug: serving-falcon-7b-fastapi-docker
 title: Serving Falcon 7B Instruct with FastAPI and Docker
 authors: [filippopedrazzinfp]
 tags: [llm, self-hosted, prem, open-source, fastapi, docker, falcon-7b]
+description: "In this tutorial, we will walk you through the process of serving the Falcon 7B Instruction model using FastAPI and Docker. The complete code for this tutorial is available on GitHub."
+image: "./banner.jpg"
 ---
-
+<!--truncate-->
 ![Prem Banner](./banner.jpg)
 
 <head>
@@ -12,7 +14,6 @@ tags: [llm, self-hosted, prem, open-source, fastapi, docker, falcon-7b]
 </head>
 
 In this tutorial, we will walk you through the process of serving the Falcon 7B Instruction model using FastAPI and Docker. The complete code for this tutorial is available on [GitHub](https://github.com/premAI-io/llm-fastapi-docker-template).
-<!--truncate-->
 
 > NOTE: in order to run Falcon 7B Instruct model you will need a GPU with at least 16GiB of VRAM. You can use a [Paperspace Cloud](https://www.paperspace.com/gpu-cloud) virtual server or any other cloud provider or your own server with a NVIDIA GPU.
 

--- a/blog/2023-07-05-chainlit-langchain-qa/index.md
+++ b/blog/2023-07-05-chainlit-langchain-qa/index.md
@@ -1,15 +1,15 @@
 ---
 slug: chainlit-langchain-prem
 title: Talk to your Data with ChainLit and Langchain
-authors: [tiero, filippopedrazzinfp]
-tags: [llm, self-hosted, prem, open-source, langchain, chainlit, vicuna-7b, chroma, vector-store]
+authors: [ tiero, filippopedrazzinfp ]
+tags: [ llm, self-hosted, prem, open-source, langchain, chainlit, vicuna-7b, chroma, vector-store ]
+description: 'Build a chatbot that talks to your data with Prem using LangChain, Chainlit, Chroma Vector Store and Vicuna 7B model, self-hosted on your MacOS laptop.'
+image: './chainlit-langchain.gif'
 ---
+<!--truncate-->
 Build a chatbot that talks to your data with [Prem](https://premai.io) using `LangChain`, `Chainlit`, `Chroma` Vector Store and `Vicuna 7B` model, self-hosted on your MacOS laptop.
 
 ![ChainLit x Langchain Screenshot](./chainlit-langchain.gif)
-
-
-<!--truncate-->
 
 ### What is ChainLit?
 

--- a/src/theme/BlogPostItem/Container/index.js
+++ b/src/theme/BlogPostItem/Container/index.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import {useBaseUrlUtils} from '@docusaurus/useBaseUrl';
+import {useBlogPost} from '@docusaurus/theme-common/internal';
+export default function BlogPostItemContainer({children, className}) {
+  const {frontMatter, assets} = useBlogPost();
+  const {withBaseUrl} = useBaseUrlUtils();
+  const image = assets.image ?? frontMatter.image;
+
+  return (
+    <article
+      className={className}
+      itemProp="blogPost"
+      itemScope
+      itemType="http://schema.org/BlogPosting">
+      {image && (
+        <meta itemProp="image" content={withBaseUrl(image, {absolute: true})} />
+      )}
+      {children}
+    </article>
+  );
+}

--- a/src/theme/BlogPostItem/Content/index.js
+++ b/src/theme/BlogPostItem/Content/index.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import clsx from 'clsx';
+import {blogPostContainerID} from '@docusaurus/utils-common';
+import {useBlogPost} from '@docusaurus/theme-common/internal';
+import MDXContent from '@theme/MDXContent';
+import {useBaseUrlUtils} from "@docusaurus/useBaseUrl";
+
+export default function BlogPostItemContent({children, className}) {
+  const {isBlogPostPage, frontMatter, assets} = useBlogPost();
+  const {withBaseUrl} = useBaseUrlUtils();
+  const image = assets.image ?? frontMatter.image;
+
+  return (
+    <div
+      // This ID is used for the feed generation to locate the main content
+      id={isBlogPostPage ? blogPostContainerID : undefined}
+      className={clsx('markdown', className)}
+      itemProp="articleBody">
+      {isBlogPostPage ?
+        <MDXContent>{children}</MDXContent>
+        : (
+          <div style={{display: "flex", gap: '2%'}}>
+            <p style={{flexBasis: '66.66%'}}>{frontMatter.description}</p>
+            <p style={{flexBasis: '33.33%'}}>
+              <img src={withBaseUrl(image, {absolute: true})} alt=""/>
+            </p>
+          </div>
+        )}
+    </div>
+  );
+}

--- a/src/theme/BlogPostItem/Footer/ReadMoreLink/index.js
+++ b/src/theme/BlogPostItem/Footer/ReadMoreLink/index.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import Translate, {translate} from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
+function ReadMoreLabel() {
+  return (
+    <b>
+      <Translate
+        id="theme.blog.post.readMore"
+        description="The label used in blog post item excerpts to link to full blog posts">
+        Read More
+      </Translate>
+    </b>
+  );
+}
+export default function BlogPostItemFooterReadMoreLink(props) {
+  const {blogPostTitle, ...linkProps} = props;
+  return (
+    <Link
+      aria-label={translate(
+        {
+          message: 'Read more about {title}',
+          id: 'theme.blog.post.readMoreLabel',
+          description:
+            'The ARIA label for the link to full blog posts from excerpts',
+        },
+        {title: blogPostTitle},
+      )}
+      {...linkProps}>
+      <ReadMoreLabel />
+    </Link>
+  );
+}

--- a/src/theme/BlogPostItem/Footer/index.js
+++ b/src/theme/BlogPostItem/Footer/index.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import clsx from 'clsx';
+import {useBlogPost} from '@docusaurus/theme-common/internal';
+import EditThisPage from '@theme/EditThisPage';
+import TagsListInline from '@theme/TagsListInline';
+import ReadMoreLink from '@theme/BlogPostItem/Footer/ReadMoreLink';
+import styles from './styles.module.css';
+export default function BlogPostItemFooter() {
+  const {metadata, isBlogPostPage} = useBlogPost();
+  const {tags, title, editUrl, hasTruncateMarker} = metadata;
+  // A post is truncated if it's in the "list view" and it has a truncate marker
+  const truncatedPost = !isBlogPostPage && hasTruncateMarker;
+  const tagsExists = tags.length > 0;
+  const renderFooter = tagsExists || truncatedPost || editUrl;
+  if (!renderFooter) {
+    return null;
+  }
+  return (
+    <footer
+      className={clsx(
+        'row docusaurus-mt-lg',
+        isBlogPostPage && styles.blogPostFooterDetailsFull,
+      )}>
+      {tagsExists && (
+        <div className={clsx('col', {'col--9': truncatedPost})}>
+          <TagsListInline tags={tags} />
+        </div>
+      )}
+
+      {isBlogPostPage && editUrl && (
+        <div className="col margin-top--sm">
+          <EditThisPage editUrl={editUrl} />
+        </div>
+      )}
+
+      {truncatedPost && (
+        <div
+          className={clsx('col text--right', {
+            'col--3': tagsExists,
+          })}>
+          <ReadMoreLink blogPostTitle={title} to={metadata.permalink} />
+        </div>
+      )}
+    </footer>
+  );
+}

--- a/src/theme/BlogPostItem/Footer/styles.module.css
+++ b/src/theme/BlogPostItem/Footer/styles.module.css
@@ -1,0 +1,3 @@
+.blogPostFooterDetailsFull {
+  flex-direction: column;
+}

--- a/src/theme/BlogPostItem/Header/Author/index.js
+++ b/src/theme/BlogPostItem/Header/Author/index.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import clsx from 'clsx';
+import Link from '@docusaurus/Link';
+function MaybeLink(props) {
+  if (props.href) {
+    return <Link {...props} />;
+  }
+  return <>{props.children}</>;
+}
+export default function BlogPostItemHeaderAuthor({author, className}) {
+  const {name, title, url, imageURL, email} = author;
+  const link = url || (email && `mailto:${email}`) || undefined;
+  return (
+    <div className={clsx('avatar margin-bottom--sm', className)}>
+      {imageURL && (
+        <MaybeLink href={link} className="avatar__photo-link">
+          <img className="avatar__photo" src={imageURL} alt={name} />
+        </MaybeLink>
+      )}
+
+      {name && (
+        <div
+          className="avatar__intro"
+          itemProp="author"
+          itemScope
+          itemType="https://schema.org/Person">
+          <div className="avatar__name">
+            <MaybeLink href={link} itemProp="url">
+              <span itemProp="name">{name}</span>
+            </MaybeLink>
+          </div>
+          {title && (
+            <small className="avatar__subtitle" itemProp="description">
+              {title}
+            </small>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/theme/BlogPostItem/Header/Authors/index.js
+++ b/src/theme/BlogPostItem/Header/Authors/index.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import clsx from 'clsx';
+import {useBlogPost} from '@docusaurus/theme-common/internal';
+import BlogPostItemHeaderAuthor from '@theme/BlogPostItem/Header/Author';
+import styles from './styles.module.css';
+// Component responsible for the authors layout
+export default function BlogPostItemHeaderAuthors({className}) {
+  const {
+    metadata: {authors},
+    assets,
+  } = useBlogPost();
+  const authorsCount = authors.length;
+  if (authorsCount === 0) {
+    return null;
+  }
+  const imageOnly = authors.every(({name}) => !name);
+  return (
+    <div
+      className={clsx(
+        'margin-top--md margin-bottom--sm',
+        imageOnly ? styles.imageOnlyAuthorRow : 'row',
+        className,
+      )}>
+      {authors.map((author, idx) => (
+        <div
+          className={clsx(
+            !imageOnly && 'col col--6',
+            imageOnly ? styles.imageOnlyAuthorCol : styles.authorCol,
+          )}
+          key={idx}>
+          <BlogPostItemHeaderAuthor
+            author={{
+              ...author,
+              // Handle author images using relative paths
+              imageURL: assets.authorsImageUrls[idx] ?? author.imageURL,
+            }}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/theme/BlogPostItem/Header/Authors/styles.module.css
+++ b/src/theme/BlogPostItem/Header/Authors/styles.module.css
@@ -1,0 +1,14 @@
+.authorCol {
+  max-width: inherit !important;
+  flex-grow: 1 !important;
+}
+
+.imageOnlyAuthorRow {
+  display: flex;
+  flex-flow: row wrap;
+}
+
+.imageOnlyAuthorCol {
+  margin-left: 0.3rem;
+  margin-right: 0.3rem;
+}

--- a/src/theme/BlogPostItem/Header/Info/index.js
+++ b/src/theme/BlogPostItem/Header/Info/index.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import clsx from 'clsx';
+import {translate} from '@docusaurus/Translate';
+import {usePluralForm} from '@docusaurus/theme-common';
+import {useBlogPost} from '@docusaurus/theme-common/internal';
+import styles from './styles.module.css';
+// Very simple pluralization: probably good enough for now
+function useReadingTimePlural() {
+  const {selectMessage} = usePluralForm();
+  return (readingTimeFloat) => {
+    const readingTime = Math.ceil(readingTimeFloat);
+    return selectMessage(
+      readingTime,
+      translate(
+        {
+          id: 'theme.blog.post.readingTime.plurals',
+          description:
+            'Pluralized label for "{readingTime} min read". Use as much plural forms (separated by "|") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)',
+          message: 'One min read|{readingTime} min read',
+        },
+        {readingTime},
+      ),
+    );
+  };
+}
+function ReadingTime({readingTime}) {
+  const readingTimePlural = useReadingTimePlural();
+  return <>{readingTimePlural(readingTime)}</>;
+}
+function Date({date, formattedDate}) {
+  return (
+    <time dateTime={date} itemProp="datePublished">
+      {formattedDate}
+    </time>
+  );
+}
+function Spacer() {
+  return <>{' · '}</>;
+}
+export default function BlogPostItemHeaderInfo({className}) {
+  const {metadata} = useBlogPost();
+  const {date, formattedDate, readingTime} = metadata;
+  return (
+    <div className={clsx(styles.container, 'margin-vert--md', className)}>
+      <Date date={date} formattedDate={formattedDate} />
+      {typeof readingTime !== 'undefined' && (
+        <>
+          <Spacer />
+          <ReadingTime readingTime={readingTime} />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/theme/BlogPostItem/Header/Info/styles.module.css
+++ b/src/theme/BlogPostItem/Header/Info/styles.module.css
@@ -1,0 +1,3 @@
+.container {
+  font-size: 0.9rem;
+}

--- a/src/theme/BlogPostItem/Header/Title/index.js
+++ b/src/theme/BlogPostItem/Header/Title/index.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import clsx from 'clsx';
+import Link from '@docusaurus/Link';
+import {useBlogPost} from '@docusaurus/theme-common/internal';
+import styles from './styles.module.css';
+export default function BlogPostItemHeaderTitle({className}) {
+  const {metadata, isBlogPostPage} = useBlogPost();
+  const {permalink, title} = metadata;
+  const TitleHeading = isBlogPostPage ? 'h1' : 'h2';
+  const titleStyle = isBlogPostPage ? styles.title : styles.titleIndex
+  return (
+    <TitleHeading className={clsx(titleStyle, className)} itemProp="headline">
+      {isBlogPostPage ? (
+        title
+      ) : (
+        <Link itemProp="url" to={permalink}>
+          {title}
+        </Link>
+      )}
+    </TitleHeading>
+  );
+}

--- a/src/theme/BlogPostItem/Header/Title/styles.module.css
+++ b/src/theme/BlogPostItem/Header/Title/styles.module.css
@@ -1,0 +1,23 @@
+.title {
+  font-size: 3rem;
+}
+
+/**
+  Blog post title should be smaller on smaller devices
+**/
+@media (max-width: 576px) {
+  .title {
+    font-size: 2rem;
+  }
+}
+
+/* Blog Index page */
+.titleIndex {
+  font-size: 2.3rem;
+}
+@media (max-width: 576px) {
+  .titleIndex {
+    font-size: 1.6rem;
+  }
+}
+

--- a/src/theme/BlogPostItem/Header/index.js
+++ b/src/theme/BlogPostItem/Header/index.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import BlogPostItemHeaderTitle from '@theme/BlogPostItem/Header/Title';
+import BlogPostItemHeaderInfo from '@theme/BlogPostItem/Header/Info';
+import BlogPostItemHeaderAuthors from '@theme/BlogPostItem/Header/Authors';
+export default function BlogPostItemHeader() {
+  return (
+    <header>
+      <BlogPostItemHeaderTitle />
+      <BlogPostItemHeaderInfo />
+      <BlogPostItemHeaderAuthors />
+    </header>
+  );
+}

--- a/src/theme/BlogPostItem/index.js
+++ b/src/theme/BlogPostItem/index.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import clsx from 'clsx';
+import {useBlogPost} from '@docusaurus/theme-common/internal';
+import BlogPostItemContainer from '@theme/BlogPostItem/Container';
+import BlogPostItemHeader from '@theme/BlogPostItem/Header';
+import BlogPostItemContent from '@theme/BlogPostItem/Content';
+import BlogPostItemFooter from '@theme/BlogPostItem/Footer';
+
+// apply a bottom margin in list view
+function useContainerClassName() {
+  const {isBlogPostPage} = useBlogPost();
+  return !isBlogPostPage ? 'margin-bottom--xl' : undefined;
+}
+
+export default function BlogPostItem({children, className}) {
+  const containerClassName = useContainerClassName();
+  return (
+    <BlogPostItemContainer className={clsx(containerClassName, className)}>
+      <BlogPostItemHeader />
+      <BlogPostItemContent>{children}</BlogPostItemContent>
+      <BlogPostItemFooter />
+    </BlogPostItemContainer>
+  );
+}

--- a/src/theme/TagsListInline/index.js
+++ b/src/theme/TagsListInline/index.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Tag from '@theme/Tag';
+import styles from './styles.module.css';
+export default function TagsListInline({tags}) {
+  return (
+    <>
+      <ul className={clsx(styles.tags, 'padding--none')}>
+        {tags.map(({label, permalink: tagPermalink}) => (
+          <li key={tagPermalink} className={styles.tag}>
+            <Tag label={label} permalink={tagPermalink} />
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}

--- a/src/theme/TagsListInline/styles.module.css
+++ b/src/theme/TagsListInline/styles.module.css
@@ -1,0 +1,8 @@
+.tags {
+  display: inline;
+}
+
+.tag {
+  margin: 0 0.4rem 0.5rem 0;
+  display: inline-block;
+}


### PR DESCRIPTION
The main idea is to duplicate `description` and `image path` in frontMatter metadata, so that those two elements can be customized. Otherwise we receive a MDX object can't be customized.

We have ejected two components from the default theme:
`yarn swizzle @docusaurus/theme-classic BlogPostItem`
`yarn swizzle @docusaurus/theme-classic TagsListInline`

@casperdcl @tiero @filopedraz If you validate the idea (which is definitely hacky but didn't find better), I can style the page further.
