### PR TITLE
Install instructions for Linux points users to http://localhost:8000.…

### DIFF
--- a/docs/prem-app/installation/install-linux-production.md
+++ b/docs/prem-app/installation/install-linux-production.md
@@ -42,4 +42,4 @@ cd ./prem-app
 docker-compose -f docker-compose.yml -f docker-compose.gpu.yml up -d
 ```
 
-And you will have the UI at `http://{localhost|server_ip}:8000`.
+And you will have the UI at `http://{localhost|server_ip}:8080`.


### PR DESCRIPTION
… Should this be http://localhost:8080 instead? Port 8080 seems to be App/UI interface port when I install on my Ubuntu machine. The docker-compose.yml seems to indicate this is the port, also?